### PR TITLE
Headwords: handle immediate linebreaks in descriptions

### DIFF
--- a/parser/src/parser/page.py
+++ b/parser/src/parser/page.py
@@ -126,7 +126,11 @@ class Page:
                     if _line_is_entry(line):
                         entries_for_letter.append(line)
                     else:
-                        entries_for_letter[-1] = f"{entries_for_letter[-1]}{line}"
+                        # Line may contain linebreaks, which are not required at the beginning.
+                        line_without_breaks = line.lstrip("\\n")
+                        entries_for_letter[
+                            -1
+                        ] = f"{entries_for_letter[-1]} {line_without_breaks}"
 
             raw_entries = raw_entries[0:-2] + entries_for_letter
 

--- a/parser/tests/test_dictionary.py
+++ b/parser/tests/test_dictionary.py
@@ -37,7 +37,7 @@ def test_combines_entries() -> None:
         "Væverskib",
         "Væverskøjte",
         "Væverskøn",
-        "Væverestuve,0",
+        "Væverestuve",
         "Væveri",
         "Væve(r)ske",
         "Vævig",
@@ -79,8 +79,7 @@ def test_combines_entries() -> None:
         "Ymle",
         "Ymme",
         "Ymmel",
-        # TODO: GH-46 "Ymte,hafide",  false positive linebreak combination.
-        # TODO: GH-46, the above entry is dropped as false-positive invalid.
+        "Ymte",
         "Ymne",
         "Yderst",
         "Ymnu",

--- a/parser/tests/test_page_splitter.py
+++ b/parser/tests/test_page_splitter.py
@@ -112,11 +112,14 @@ def test_splits_page_of_unknown_first_letter_correctly() -> None:
         "om areth, sagefaldh oc brøde (1493). D. Mag. IV. 12. Vistnok = ejgt (9: ægt), se d. 0."
     )
 
-    expected_f_headwords = ["Fabel", "Fabelhøne,.no.", "Fabel", "Fabian", "Fad"]
+    expected_f_headwords = ["Fabel", "Fabelhøne", "Fabel", "Fabian", "Fad"]
 
     assert [entry.headword for entry in f_entries] == expected_f_headwords
 
-    assert f_entries[1].definitions == "= fabelhans (om kvinder). Moth. Smlgn. byhøne."
+    assert (
+        f_entries[1].definitions
+        == ".no. = fabelhans (om kvinder). Moth. Smlgn. byhøne."
+    )
 
 
 def test_splits_page_of_numbers_in_column_separators() -> None:


### PR DESCRIPTION
Immediate linebreak would make later "split by first word" parsing fail, as there is linebreak before first space. For those cases, trim linebreaks to get proper headword content.

Closes #46