### PR TITLE
Meta lines: custom index by page name

### DIFF
--- a/parser/src/parser/columns.py
+++ b/parser/src/parser/columns.py
@@ -1,5 +1,7 @@
 from typing import Final
 
+from src.parser.meta_line import MetaLine
+
 _vertical_divider: Final[str] = "|"
 _exlamation_divider: Final[str] = " ! "
 _spaces_divider: Final[str] = "   "
@@ -48,11 +50,14 @@ def _get_divided_lines(line: str) -> list[str]:
     return [line[: len(line) // 2], line[len(line) // 2 :]]  # noqa: E203
 
 
-def parse_column(page: list[str]) -> list[str]:
+def parse_column(page: list[str], name: str) -> list[str]:
     left_column = []
     right_column = []
 
-    for line in page[1:]:  # First line is meta info.
+    meta_line_index = MetaLine.get_meta_line_index(name=name, lines=page)
+    content_start_index = meta_line_index + 1  # Dont parse meta into columns.
+
+    for line in page[content_start_index:]:
         if len(line) > 20:  # Skip letter headings and oddities.
             divided = _get_divided_lines(line)
 
@@ -69,13 +74,4 @@ def parse_column(page: list[str]) -> list[str]:
                     print("Unexpected split!")
                     print(line)
 
-    return [page[0]] + left_column + right_column
-
-
-def parse_columns(pages: list[list[str]]) -> list[list[str]]:
-    single_column_pages = []
-
-    for page in pages:
-        single_column_pages.append(parse_column(page))
-
-    return single_column_pages
+    return [page[meta_line_index]] + left_column + right_column

--- a/parser/src/parser/dictionary.py
+++ b/parser/src/parser/dictionary.py
@@ -25,7 +25,13 @@ class Dictionary:
                 pages.append(page1)
                 pages.append(page2)
             else:
-                pages.append(Page(lines=columns.parse_column(dictionary_page.lines)))
+                pages.append(
+                    Page(
+                        lines=columns.parse_column(
+                            dictionary_page.lines, name=dictionary_page.name
+                        )
+                    )
+                )
 
         self._pages = pages
 

--- a/parser/src/parser/meta_line.py
+++ b/parser/src/parser/meta_line.py
@@ -1,0 +1,28 @@
+from typing import Final
+
+PAGES_TO_IRREGULAR_META_LINE_INDEXES: Final[dict[str, int]] = {
+    "71-arbejdelse.txt": 1,
+    "430-eftergøre.txt": 1,
+    "875-gildeskorn.txt": 1,
+    "897-gnistne.txt": 1,
+    "1109-hosskrift.txt": 1,  # TODO GH-58: maybe test case?
+    "1138-husbrand.txt": 1,  # TODO GH-58: maybe test case?
+    "1233-indermere (inderst).txt": 1,  # TODO GH-58: maybe test case?
+    "1267-istædelæder.txt": 1,
+    "1289-jorsal.txt": 1,
+    "1400-knuderig.txt": 2,
+    "1461-krejge.txt": 1,
+    "1508-kvartaladmiral.txt": 1,
+    "1532-kæbel.txt": 2,
+    "1549-kølve.txt": 1543,  # TODO GH-58: maybe test case?
+    "2514-skibels(e).txt": 1,  # TODO GH-58: maybe test case?
+    "2523-skinbarlig.txt": 1,  # TODO GH-58: maybe test case?
+    "2530-skjudebane.txt": 2,  # TODO GH-58: maybe test case?
+    "2648-snablet.txt": 1,
+}
+
+
+class MetaLine:
+    @staticmethod
+    def get_meta_line_index(name: str, lines: list[str]) -> int:
+        return PAGES_TO_IRREGULAR_META_LINE_INDEXES.get(name, 0)

--- a/parser/src/parser/page.py
+++ b/parser/src/parser/page.py
@@ -11,6 +11,7 @@ class Page:
     _letters_in_page: list[str] | None = None
 
     def __init__(self, lines: list[str]) -> None:
+        # While pages have irregular meta lines, column parsing should've offsetted it already.
         self.meta = lines[0]
         self.content = lines[1:]
 
@@ -94,7 +95,8 @@ class Page:
 
     def get_entries(self) -> list[Entry]:
         def _line_is_entry(line: str) -> bool:
-            parts = line.split(" ")
+            # Break into words, omitting spacing the beginning.
+            parts = line.lstrip().split(" ")
 
             # Some exotic parts do not respect length, probably linebreakish thing.
             # If it breaks, its not an entry.

--- a/parser/src/parser/page_splitter.py
+++ b/parser/src/parser/page_splitter.py
@@ -40,9 +40,14 @@ class PageSplitter:
         split_point = LETTER_SPLIT_MAPPING[filename]
 
         # Split by the split point, but append meta line to the second part too.
-        combined_column_1_lines = parse_column(lines[0:split_point])
-        combined_column_2_lines = parse_column([lines[0]] + lines[split_point:])
-        page1, page2 = (Page(combined_column_1_lines), Page(combined_column_2_lines))
+        combined_column_1_lines = parse_column(page=lines[0:split_point], name=filename)
+        combined_column_2_lines = parse_column(
+            page=[lines[0]] + lines[split_point:], name=filename
+        )
+        page1, page2 = (
+            Page(lines=combined_column_1_lines),
+            Page(lines=combined_column_2_lines),
+        )
 
         # We expect pages to have two letters maximum.
         letters = page1.get_letters_in_page()

--- a/parser/tests/test_columns.py
+++ b/parser/tests/test_columns.py
@@ -27,6 +27,6 @@ def test_column_combining() -> None:
         "over Ingeborg Gyldenstjerne.",
     ]
 
-    result = columns.parse_column(input)
+    result = columns.parse_column(input, "dummy-name")
 
     assert result == expected

--- a/parser/tests/test_data/simple-page-irregular-meta-line.txt
+++ b/parser/tests/test_data/simple-page-irregular-meta-line.txt
@@ -1,0 +1,56 @@
+|
+72                     Arbejdelse—årg
+dég, 1530. h2 &= Uvicf VOL 215: | 219; som aff sveldhe søedh Worst haffoer
+— Arbejdelse, no. arbejde; factio, | (1500): Fynske Aktstk: 99; (1503).
+faciendi actus, arbeidelse, Colding, | sst. 149; (1516). Gel. Ark. Arsb.
+Ftymol. 374. — Arbejdere; no: år- | HI. till. 94; som bondsettninge haffuer
+bejder; en vol proued arbeydere. | været aft arlldé (1592). Rosenv; Gl:
+Tim. 234 (Chr. Pedersen, 1550, | L. IV. 100; (1492). N. D: Mag: I.
+1647); Visd. 17.17 (1580 og 1647); — | 30; som icke aft aiilde sednane vVertit
+in atbeyder. Chr. Pedersen, Matih. | haffåer. Hvitf. VIN. 57; S6t Il. 274; —
+1030; — fit: i din høst tro arbeder | som wærit haffue blant christet folek
+send. Psalmeb: 148b; udgiven løn | aff arilde tid. P. Dliesen. 104; ssom
+gjør fule arbedere. P: Syv: I. 247. | aff afeld tid kronen haffuer hafftk att
+Åxbejdsom, to. 1) i muv. bet. ; flittige | forlæg (1834). N. D. Mag. V. 183;
+oe arbedtssomme tienete. A. Bernt- | Gud er min konge aff arildtid. Ps.
+sen. II. 124, — 2) møjsommelig; | 74.2; — hsf. fit.: som aff srildom
+heller vilde attrage en lystig oc rolig | væreth - haffuer (1484). D. Mag. I.
+ting end en mødsohimelig oc arbeyd- | 271; — éjef. som to. : tHet af skiicke
+som. B. Tott. III, 138: — Årbejd- | wti sin æreldhæ wt giiffth (1499). Geh:
+somhed, no. møje; deris fald fra fri- | Ark. Årsb: V. 85; som ærelde set-
+hed ti) arbeydsomhed oc trældom. | wanæ warithhaffier. sst. V.86; smløn.
+Gerner, Hesiodus. dedic. 5.     æreste. — Areldsæd, no. ældgam-
+Axbørst, se armbørst.           mel sædvane; tlet hathe været
+Ardag, no. (Lund) pløjning; tha | een areld séeth (1433). Weinwich,
+årøver bode pløwer oc herræ, ardagh | Stevns Herred. 70; som arlld seedh
+oe saa ther til sæde. The femthen | wæreth hafluer (1485). Hiberts,
+teghen, 1509. a?.              Aktstk. om Århus, I: 47.
+Ardzmesse, no. sjælemesse; for     Arene, no. ? saa mange arene o0
+en ardz messe oc en begengelse (1474). | kårene oc afflosning i jomfru Maria.
+D. Mag. VI. 125; vardze smtrk. for | Pallad., S. Ped. Skib. b3; etherss
+årtid, se dette ord.                siind och sambvwittigheedh konde icke
+Are, no. havre; scylder aaxligen ij | bliffue tryg och fridssommeligh aff
+pund biug, j ørte are ... j pund are | sriner och kariner, Tavsen. 9. Måske
++ + 3j gies, i) sciper are (1625). Hist, | = arenga hosDu Cange, fr. harangue?
+Tdskr. 3. R. I. 409. Efter A. D.    Arfbidt, to: ramt; arfbidt af bøsse-
+Jørgensen (D. Saml. 2. R. I. 376) | mund i mange døds ulemper. Kingo,
+Skulle formerte: »arre, aure, ar« være | Chr. V. b2. Er den første del af
+alm. | jordebøger; men når sst. arve | ordet »ar«? At opfatte dette = isl. år
+(stellaria medie) forklares ved vild havre, | (ejef. rvar); mf hos Schlyter, ladet
+er dette nok botanisk urigtigt. 1 Svensk | sig vel ikke gjøre?
+bortfalder undertiden forlyden i dette |   Arg, to. slet, slem; frelse oss
+orå, se Jenssen-Tusch, Nord. | fra det arge oc onde. Tidemand,
+Planten. 31 og Rietz. 2932.      | Sjælens Urtegd. t5; du arge 00
+Arel, no. plantenavn; skalkier- | skalekactige bedragere. Vedel; Saxo.
+gordsmanden holle kiergaarden schi- | 18; der 'er ikke saa arg en fader, han
+ckelig och smuck, vpdråge tidtzler, | havde jo gerne en frommer søn. P.
+areller och amndit vnytteligt (1862). | Syv. I. 119; isl. argr er alm. = føj;
+Kbhvns, Dip). I. 483. Smlgn. amild. | smlgn. dog Fritzner.810; den anførte
+Jenssen-Tusch, Nord. Planten. | bet. alm.iNorsk, Sv.og Nt., seSch.u. Lt
+298, 344.                   ) areh. - 2g.: som vaår end verre oc argere
+Areld, no. (Lund.) gammel tid; | end hans herre. 2. Mak. 5.223 paffuen
+engen hawæ hafn wihen with køph- er argere enå Tørokere oc Jøder
+stætherne, som the af ærlld hawe | Tidemand, Post. II. 15. — 36
+wæret (1398). Molb. o. Peters. 58; | som n0. skade; then, som umgaar
+Dipl. Chr. I. 379; som aff æreldh | met stadhsens årgeste swo, at han
+Tærithaftuer (1454). Rosenv.,G1.L.V. | stadhen | forradhe tller brænne Vil


### PR DESCRIPTION
While majority of the pages have meta line as their first line, some OCR results are a bit wonky and it may actually be the second or third line. Add mapping to handle these exceptions.

Closes #52