### PR TITLE
Entry parsing: add manual replaces for headword/content

### DIFF
--- a/parser/src/parser/entry.py
+++ b/parser/src/parser/entry.py
@@ -8,6 +8,10 @@ KNOWN_HEADWORD_TYPOS_TO_CORRECT_VERSIONS: Final[dict[str, str]] = {
     "Ya(eyfærdig": "Yd(e)færdig",
 }
 
+KNOWN_HEADWORD_OCR_SPLIT_ISSUES_TO_CORRECTLY_SPlIT: Final[
+    dict[str, tuple[str, str]]
+] = {"Abeganterino.narreverk.": ("Abeganteri", "no. narreverk. Moth.")}
+
 EXCEPTIONS_TO_COMMA_RULE: Final[list[str]] = ["X"]
 
 
@@ -91,6 +95,14 @@ class Entry(NamedTuple):
         # Fix known typos.
         return cls._proofread_headword(formatted_headword)
 
+    @staticmethod
+    def _maybe_replace_headword_or_content(
+        headword: str, definitions: str
+    ) -> tuple[str, str]:
+        return KNOWN_HEADWORD_OCR_SPLIT_ISSUES_TO_CORRECTLY_SPlIT.get(
+            headword, (headword, definitions)
+        )
+
     @classmethod
     def from_raw_entry(
         cls, raw_entry: str, allowed_start_letters: list[str]
@@ -116,6 +128,10 @@ class Entry(NamedTuple):
         if len(headword) > 0 and headword[-1] == "-":
             headword = f"{headword[0:-1]}{definitions.split(' ')[0]}"
             definitions = " ".join(definitions.split(" ")[1:])
+
+        headword, definitions = cls._maybe_replace_headword_or_content(
+            headword, definitions
+        )
 
         return Entry(
             headword=cls._clean_headword_presentation(headword, allowed_start_letters),

--- a/parser/tests/test_data/first-page.txt
+++ b/parser/tests/test_data/first-page.txt
@@ -1,0 +1,43 @@
+Abbot abbot 1
+Åbbot, no. (Int. abbas, isl. åbéti) | Weigere. 215, 228%; lige som man ick
+1) abbed; abbuten aff Skow kloster, | kunde aben kende, naar hun sig før i
+D. Mag. I. 367; skriftede han seg | Aarons klæder. Ranch. 29; løb løss
+for en abboth. Romant. Digtn. III, | en tam abe, der mand lockede ad
+114, 181.6; abbet. Chr. Pedersen. | hende. Hvitf VIL 1; aben, som bilder
+V. 10.3, 123.24; (abbeden. P. Smed. | sig ind, at hendis børn er altijd de
+i 2), — ft: fangætæ cardinale oc | smuckeste. S. Terkelsen, Astreæ
+abbethæ. N. D. Mag. V. 180; abbede | Sjungek. IL. fort. — 2) fjfr. isl. api.)
+oc muncke, Bruun, Viserf. Reform. | dåre; wthen han seer ther tijl ful-
+37. — 2) abbed bruges i drikke- | breth, tha holles han forenabe., Rimkr.
+selskab og bemerker den, som | p%; giør du Joab, Herre, til din abe,
+begynder skålen og kommer de | at hans anslag ey due. Ranch. 95;
+andre til at drikke; nu rider | en nar, den, som holder for-
+abbeden; jam vobis author sum bi- | meget af sine børn. Moth. —
+bendi. Moth; der drikkes duus, da | Abears, no. en frugt, som vokser
+skriver mand hinanden op for knæ- | på mispeltræ. Moth; se Jenssen -
+ling, da rider abbeden. P. Syv. II. 152. | Tuseh, Nord. Plantenavne 147;
+Abbed bragtes oftere om formanden | Seh. u. L.: spenårseken; smign. ogs.
+for lystige lag, se Du Cange: abbas | åbenars. — Abefugl, no. = abe 2); vdi
+lætitiæ; »jouer å Fabbé, jen 0å Fon est | Franckerige mørder oc røffuer de oc
+obligé de faire tout ce, que fait celui, | haffde k. Karl kun foren abefuel. Hvitf.
+qui a été designé pour chef et qwon | 1. 79. — Abegabe, 1) go. at ståe og
+nomme abbé.« Littré; »den abt reiten | gloe og gabe. — 2) no. narreri;
+lassen bedeatet sich ungeswungen lustig | skikke en efter abegabe, exorcere ali-
+machen,« Sanders. Måske udtrykket | quem. Moth. — Abegant,no.1) narre -
+»ride«. sigter til skikkene ved æsels- | værk; vi bruger ingenabegant. Ranch.
+og narrefesterne; smlgn. også V. 9. 0.: | 141, 159; abegant, ludibrium. Colding,
+elbisp og ølprovst. — Abbeddømme, | Dict. Herlov.; Bording. II. 22. —
+no. fit. ufor.; kom nogle abbeddømme | 2) nar; i giorde mig smuct thill abe-
+paa fode igien. Hvitf. I. pp. 4%; smlgn. | gant. Ranch. 190, 192; en gek og
+biskops- fyrste- grevedømme. — Abba- | gante.Moth.—Abeganterino.narre-
+tisse, no. (lat. abbatissa) abbedisse; | verk. Moth. — Aberøv, no. = abears
+skulde the lofiwæ abbatissen at wæræ | Moth. — Abespil, no. (nt. apenspel.
+troo i allæ closters ærende (1488). N. | Sch. u. L.) spot; giøre en skompel-
+D. Mag. VI. 225; abadisse. P. Syv. | skud oc et affuespil aff hanss fattige
+I 12.                        discipel. Tavsen, Jesu passies
+
+Abe, no. 1) dyrenavn, hunk. (cv sv. | hystori 17; smlgn. sv. apspel. —
+apa.); som aben tit skeer, naar hun | Abe, go. 1) skabe sig (efter); som
+vil gøre effter det, hun seer. Herm. ' det papistiske folok haffuer nock abet
+
+1

--- a/parser/tests/test_page.py
+++ b/parser/tests/test_page.py
@@ -162,3 +162,50 @@ def test_parses_simple_entries_from_irregular_offset_page() -> None:
 
     assert [entry.headword for entry in entries] == expected_headwords
     assert [entry.status for entry in entries] == expected_statuses
+
+
+def test_parses_entries_from_first_page() -> None:
+    """
+    First page in dictionary portrays many irregularities in OCR, which makes detecting
+    entries trickier. Includes manual exception for Abeganteri.
+    """
+    irregular_lines_input = _single_column_test_file(
+        file="first-page.txt",
+        name="0-abbot.txt",
+    )
+
+    page = Page(lines=irregular_lines_input)
+    entries = page.get_entries()
+
+    expected_headwords = [
+        "Åbbot,",
+        "Abbeddømme",
+        "Abbatisse",
+        "Abe",
+        "Abears",
+        "Abefugl",
+        "Abegabe",
+        "Abegant",
+        "Abeganteri",
+        "Aberøv",
+        "Abespil",
+        "Abe",
+    ]
+
+    expected_statuses = [
+        EntryStatus.PART_OF_PREVIOUS_ENTRY,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+        EntryStatus.VALID,
+    ]
+
+    assert [entry.headword for entry in entries] == expected_headwords
+    assert [entry.status for entry in entries] == expected_statuses


### PR DESCRIPTION
To be used in cases where an entry is detected, but parsing is incorrect enough that fixing typos via mapping wont work. For example, "Abeganteri", who is glued together with part of its definition.

Has to be fixed manually, so lets add a mapping for such entries.

Closes #51 