### PR TITLE
Add autoreplace for entries whose first letter seems incorrect

### DIFF
--- a/parser/src/parser/page.py
+++ b/parser/src/parser/page.py
@@ -10,6 +10,7 @@ METALINE_ENTRY_SEPARATOR: Final[str] = "—"
 class Page:
     _meta_parts: list[str] | None = None
     _letters_in_page: list[str] | None = None
+    _incorrect_letters_in_page: list[str] = []
 
     def __init__(self, lines: list[str]) -> None:
         # While pages have irregular meta lines, column parsing should've offsetted it already.
@@ -100,6 +101,10 @@ class Page:
                 if not letters_are_sequantial(
                     first_letter, second_letter
                 ) or is_before_in_alphabet(second_letter, first_letter):
+                    # Preserve incorrect letters -> they might be used to
+                    # detect & fix malformatted headwords.
+                    self._incorrect_letters_in_page.append(second_letter)
+
                     # Default to using first letter for all.
                     letters_list = [first_letter]
 
@@ -164,7 +169,9 @@ class Page:
         # Format string entries to structures.
         entries = [
             Entry.from_raw_entry(
-                raw_entry=raw_entry, allowed_start_letters=self.get_letters_in_page()
+                raw_entry=raw_entry,
+                allowed_start_letters=self.get_letters_in_page(),
+                known_incorrect_letters=self._incorrect_letters_in_page,
             )
             for raw_entry in raw_entries
             # Some lines are either empty, or consists of title letter, or consist of linebreaks.

--- a/parser/tests/test_page.py
+++ b/parser/tests/test_page.py
@@ -167,7 +167,7 @@ def test_parses_simple_entries_from_irregular_offset_page() -> None:
 def test_parses_entries_from_first_page() -> None:
     """
     First page in dictionary portrays many irregularities in OCR, which makes detecting
-    entries trickier. Includes manual exception for Abeganteri.
+    entries trickier. Includes manual exception for Abeganteri & letter fixing for Abbot.
     """
     irregular_lines_input = _single_column_test_file(
         file="first-page.txt",
@@ -178,7 +178,7 @@ def test_parses_entries_from_first_page() -> None:
     entries = page.get_entries()
 
     expected_headwords = [
-        "Åbbot,",
+        "Abbot",
         "Abbeddømme",
         "Abbatisse",
         "Abe",
@@ -193,7 +193,7 @@ def test_parses_entries_from_first_page() -> None:
     ]
 
     expected_statuses = [
-        EntryStatus.PART_OF_PREVIOUS_ENTRY,
+        EntryStatus.VALID,
         EntryStatus.VALID,
         EntryStatus.VALID,
         EntryStatus.VALID,


### PR DESCRIPTION
This algorithm seems to work for known cases, but it prone to errors if letters in page themselves are read incorrectly. Should that happen, we can always improve the letter reading by making logic by filename instead of by OCR

Closes #63