### PR TITLE
Trim ending dashes from definitions

### DIFF
--- a/parser/src/parser/entry.py
+++ b/parser/src/parser/entry.py
@@ -61,9 +61,15 @@ class Entry(NamedTuple):
         # Drop all linebreaks.
         cleaned_definitions = raw_definitions.replace("\n", "")
 
-        return " ".join(
+        cleaned_definitions = " ".join(
             [splitted for splitted in cleaned_definitions.split(" ") if splitted != ""]
         )
+
+        # Drop ending dashes, aka breakpoints for new entries.
+        if cleaned_definitions.endswith(" —"):
+            cleaned_definitions = cleaned_definitions[0:-2]
+
+        return cleaned_definitions
 
     @staticmethod
     def _clean_headword(raw_headword: str) -> str:

--- a/parser/tests/test_dictionary.py
+++ b/parser/tests/test_dictionary.py
@@ -110,5 +110,5 @@ def test_combines_entries() -> None:
     assert entries[31].definitions == (
         "no. ko, der gaves som afgift; hwat som the giffuit haffueere en two marck for een ydhe koo (1466). "
         "DC 183; 58 ydhekiør (1523). DM4 II. 4; tilltallit kronens bønder for the icke ville yde hannom "
-        "theris yde-koer (1553). Rsv I 210. Jf Bernts Il. 179; skatteko ovf. —"
+        "theris yde-koer (1553). Rsv I 210. Jf Bernts Il. 179; skatteko ovf."
     )

--- a/parser/tests/test_page.py
+++ b/parser/tests/test_page.py
@@ -141,7 +141,7 @@ def test_parses_simple_entries() -> None:
         "er det affkommen, mand neppe kiender slecten. Hvitf. VIII 365. — 3) aflægges (t. abkommen.); at the ismaa "
         "markede ere aflagde, oc att ingen haffaer fordelle ther af, at the ere afkommen (1542). D. Mag. IV. 288. — "
         "4) overkomme; at voris depu- terede samme miinstringer, naar de afkomme kand, self skall bjwaane (1890). "
-        "Geh. Ark. Årsb. IL 294. —"
+        "Geh. Ark. Årsb. IL 294."
     )
 
     assert [entry.headword for entry in entries] == expected_headwords

--- a/parser/tests/test_page_splitter.py
+++ b/parser/tests/test_page_splitter.py
@@ -221,9 +221,8 @@ def test_splits_page_with_irregular_meta_line() -> None:
     assert [entry.headword for entry in g_entries] == expected_g_headwords
     assert [entry.headword for entry in h_entries] == expected_h_headwords
 
-    # TODO: GH-68: trim "—" and/or "" —" from ends of definitions.
-    assert g_entries[0].definitions == "no. svælg. Moth. Smlgn.1.surgel. —"
-    assert g_entries[1].definitions == "go. skylle hals. en. Moth. —"
+    assert g_entries[0].definitions == "no. svælg. Moth. Smlgn.1.surgel."
+    assert g_entries[1].definitions == "go. skylle hals. en. Moth."
     assert g_entries[2].definitions == "no. vand Ul at skylle halsen med, Moth"
     assert g_entries[4].definitions == "se u. gjord."
     assert g_entries[-1].definitions == (


### PR DESCRIPTION
Ending dashes were technically part of new headword starting, but are generally split from that point & end up as part of definitions.

Closes #68